### PR TITLE
商品情報削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :edit, :update]
+  before_action :authenticate_user!, only: [:new, :edit, :update, :destroy]
   before_action :find_item, only: [:show, :edit, :update, :destroy]
 
 
@@ -40,6 +40,8 @@ class ItemsController < ApplicationController
   def destroy
     if @item.user == current_user
       @item.destroy
+      redirect_to root_path
+    else
       redirect_to root_path
     end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit, :update]
-  before_action :find_item, only: [:show, :edit, :update]
+  before_action :find_item, only: [:show, :edit, :update, :destroy]
 
 
   def index
@@ -34,6 +34,13 @@ class ItemsController < ApplicationController
       redirect_to @item
     else
       render :edit
+    end
+  end
+
+  def destroy
+    if @item.user == current_user
+      @item.destroy
+      redirect_to root_path
     end
   end
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -23,7 +23,6 @@
         </p>
         <%= f.file_field :image, id:"item-image" %>
       </div>
-      <%#= image_tag @item.image.variant(resize:'500X500'), class: 'item-image'  if @item.image.attached? %> 
     </div>
     <%# /商品画像 %>
     <%# 商品名と商品説明 %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
       <% if @item.user == current_user %>
         <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item), method: :delete, class:"item-destroy" %>
       <% else %>
         <%# 商品が売れていない場合はこちらを表示しましょう %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>


### PR DESCRIPTION
#what
商品削除機能の実装
#why
商品削除機能を実装するため

テスト動画
ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/494312a12366236fa5168847fbcde754